### PR TITLE
Use here::here() to prevent relative path errors

### DIFF
--- a/exercises/00_welcome.qmd
+++ b/exercises/00_welcome.qmd
@@ -42,7 +42,7 @@ The following two code chunks will use the **REDCapR** package to connect to a R
 ```{r}
 library(REDCapR)
 
-creds <- retrieve_credential_local("../data-private/credentials.csv", 1)
+creds <- retrieve_credential_local(here::here("data-private", "credentials.csv"), 1)
 
 uri <- creds$redcap_uri
 token <- creds$token

--- a/exercises/01a_redcapr.qmd
+++ b/exercises/01a_redcapr.qmd
@@ -20,7 +20,7 @@ We'll discuss token approaches at the end of the deep dive. For now, know that a
 <!-- path_credential <- "redcapcon_2023_redcap_r_workshop/data-private/credentials.csv" -->
 
 ```{r}
-path_credential <- "../data-private/credentials.csv"
+path_credential <- here::here("data-private", "credentials.csv")
 credential      <- REDCapR::retrieve_credential_local(path_credential, 1L)
 credential
 ```

--- a/exercises/01b_extract_explore.qmd
+++ b/exercises/01b_extract_explore.qmd
@@ -12,7 +12,7 @@ In this exercise, we will download REDCap data using REDCapTidier (as opposed to
 library(REDCapTidieR)
 
 # Load credentials from CSV file
-creds <- REDCapR::retrieve_credential_local("../data-private/credentials.csv", 1)
+creds <- REDCapR::retrieve_credential_local(here::here("data-private", "credentials.csv"), 1)
 
 uri <- creds$redcap_uri
 token <- creds$token

--- a/exercises/exercise-1a.R
+++ b/exercises/exercise-1a.R
@@ -1,6 +1,6 @@
 # install.packages("remotes")
 # remotes::install_github("OuhscBbmc/REDCapR")
-path_credential <- "redcapcon_2023_redcap_r_workshop/data-private/credentials.csv"
+path_credential <- here::here("data-private", "credentials.csv")
 credential  <- REDCapR::retrieve_credential_local(path_credential, 1L)
 
 if (FALSE) {

--- a/solutions/00_welcome.qmd
+++ b/solutions/00_welcome.qmd
@@ -29,7 +29,7 @@ The following code chunk will use the **REDCapR** package to connect to a REDCap
 ```{r}
 library(REDCapR)
 
-creds <- retrieve_credential_local("../data-private/credentials.csv", 1)
+creds <- retrieve_credential_local(here::here("data-private", "credentials.csv"), 1)
 
 uri <- creds$redcap_uri
 token <- creds$token

--- a/solutions/01b_extract_explore.qmd
+++ b/solutions/01b_extract_explore.qmd
@@ -12,7 +12,7 @@ In this exercise, we will download REDCap data using REDCapTidier (as opposed to
 library(REDCapTidieR)
 
 # Load credentials from CSV file
-creds <- REDCapR::retrieve_credential_local("../data-private/credentials.csv", 1)
+creds <- REDCapR::retrieve_credential_local(here::here("data-private", "credentials.csv"), 1)
 
 uri <- creds$redcap_uri
 token <- creds$token

--- a/solutions/04_recreate_extend.qmd
+++ b/solutions/04_recreate_extend.qmd
@@ -15,7 +15,7 @@ In this section, your challenge is to work with your small group to recreate the
 
 library(REDCapR)
 
-creds <- retrieve_credential_local("../data-private/credentials.csv", 1)
+creds <- retrieve_credential_local(here::here("data-private", "credentials.csv"), 1)
 
 uri <- creds$redcap_uri
 token <- creds$token


### PR DESCRIPTION
Addresses issue #2 and fixes the same error where it occurs in the other files.

This fix uses Tidyverse's `here` package. `here::here()` locates the root of an Rstudio project and appends any path elements provided as parameters to create a fully qualified path to the file or directory within the project space.